### PR TITLE
client side includes and excludes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,3 +48,5 @@ burp_client_ports_per_operation:
   - 'port_verify = {{ burp_server_port_operation_verify }}'
   - 'port_list = {{ burp_server_port_operation_list }}'
   - 'port_delete = {{ burp_server_port_operation_delete }}'
+
+burp_client_server_can_override_includes: '1'

--- a/templates/burp.conf.j2
+++ b/templates/burp.conf.j2
@@ -25,4 +25,15 @@ ssl_peer_cn = {{ burp_client_ssl_peer_cn }}
 {{ l }}
 {% endfor %}
 {% endif %}
+{% if burp_client_includes is defined %}
 
+{% for include in burp_client_includes %}
+include={{ include }}
+{% endfor %}
+{% endif %}
+{% if burp_client_excludes is defined %}
+
+{% for exclude in burp_client_excludes %}
+exclude={{ exclude }}
+{% endfor %}
+{% endif %}

--- a/templates/burp.conf.j2
+++ b/templates/burp.conf.j2
@@ -24,16 +24,17 @@ ssl_peer_cn = {{ burp_client_ssl_peer_cn }}
 {% for l in burp_client_ports_per_operation %}
 {{ l }}
 {% endfor %}
-{% endif %}
-{% if burp_client_includes is defined %}
 
+{% endif %}
+server_can_override_includes = {{ burp_client_server_can_override_includes }}
+{% if burp_client_includes is defined %}
 {% for include in burp_client_includes %}
-include={{ include }}
+include = {{ include }}
 {% endfor %}
 {% endif %}
 {% if burp_client_excludes is defined %}
 
 {% for exclude in burp_client_excludes %}
-exclude={{ exclude }}
+exclude = {{ exclude }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
I added the possibility to configure client side includes and excludes. Since it may be helpful to allow the burp2 server to override those options set by a client, I enforced it.