### PR TITLE
Fix crontab burp bin path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
 - name: schedule cron.d jobs
   cron:
     name: burp client schedule
-    job: "[ -x {{ usr_dir }}/sbin/burp ] && {{ usr_dir }}/sbin/burp -c {{ burp_client_dir }}/burp.conf -a t >> {{ burp_client_logs }}/burp_client.log 2>&1"
+    job: "[ -x {{ burp_bin_path }} ] && {{ burp_bin_path }} -c {{ burp_client_dir }}/burp.conf -a t >> {{ burp_client_logs }}/burp_client.log 2>&1"
     user: root
     cron_file: burp_client
     minute: "7,27,47"


### PR DESCRIPTION
Cron job uses the wrong path for burp, pointing to /usr/bin/burp instead
of the path where burp is installed.

This commit uses the burp_bin_path variable in the cronjob
